### PR TITLE
Add a Podspec to fishhook

### DIFF
--- a/fishhook.podspec
+++ b/fishhook.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.platform = :ios, "7.0"
+  s.name = "fishhook"
+  s.summary = "A library that enables dynamically rebinding symbols in Mach-O binaries running on iOS."
+  s.homepage = "https://github.com/facebook/fishhook"
+  s.version = "1.0.0"
+  s.license = { :type => "BSD", :file => "LICENSE" }
+  s.author = { "Facebook, Inc." => "https://github.com/facebook" }
+  s.homepage = "https://github.com/facebook/fishhook"
+  s.source = { :git => "https://github.com/facebook/fishhook.git", :branch => 'master'}
+  s.source_files = "fishhook.{h,c}"
+end


### PR DESCRIPTION
Adding a podspec to fishhook so that developers can use the library with CocoaPods instead of adding the source directly to their projects. CLA has been signed.

@paolosoares @khandpur
